### PR TITLE
Fix quantity input parsing in AddItemForm

### DIFF
--- a/frontend/src/components/AddItemForm.tsx
+++ b/frontend/src/components/AddItemForm.tsx
@@ -30,7 +30,15 @@ const AddItemForm = ({
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: name === "quantity" ? parseInt(value) : value }));
+    setFormData(prev => ({
+      ...prev,
+      [name]:
+        name === "quantity"
+          ? value === "" || isNaN(parseInt(value))
+            ? 0
+            : parseInt(value)
+          : value,
+    }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- sanitize AddItemForm quantity input so empty values don't produce `NaN`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685827911a1c833187db64a4d6645201